### PR TITLE
Match more of our internal implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,15 @@
+buildscript {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+        jcenter()
+    }
+}
+
 plugins {
-    id("my-plugin")
+    kotlin("jvm") version "1.4.10"
+    id("slack.gradle")
 }
 
 slack {
@@ -12,4 +22,10 @@ slack {
             }
         }
     }
+}
+
+repositories {
+    mavenCentral()
+    google()
+    jcenter()
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,32 @@
+buildscript {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+        jcenter()
+    }
+}
 plugins {
     `kotlin-dsl`
+    `java-gradle-plugin`
+    kotlin("jvm") version "1.3.72"
 }
 
 repositories {
+    gradlePluginPortal()
     mavenCentral()
+    google()
+    jcenter()
+}
+
+gradlePlugin {
+    plugins.create("slackPlugin") {
+        id = "slack.gradle"
+        implementationClass = "slack.SlackPlugin"
+    }
+}
+
+dependencies {
+    compileOnly(gradleApi())
+    implementation("com.android.tools.build:gradle:4.0.2")
 }

--- a/buildSrc/src/main/kotlin/Aliases.kt
+++ b/buildSrc/src/main/kotlin/Aliases.kt
@@ -1,0 +1,75 @@
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.findByType
+import org.gradle.plugin.use.PluginDependenciesSpec
+import org.gradle.plugin.use.PluginDependencySpec
+import slack.AndroidHandler
+import slack.SlackAndroidAppExtension
+import slack.SlackExtension
+
+/*
+ * This file exists because of a strange behavior in Gradle. If you want to access buildSrc code from the root project's
+ * buildscript block, it cannot directly access elements that contain a package name. This is really weird, and
+ * hopefully a bug.
+ */
+
+/**
+ * Applies the given Android plugin [module].
+ *
+ * For example: `plugins { android("library") }`
+ *
+ * @param module simple name of the Android Gradle plugin module, for example "library", "application", etc...
+ */
+fun PluginDependenciesSpec.android(module: String): PluginDependencySpec =
+  id("com.android.$module")
+
+/**
+ * Common entry point for configuring slack-specific bits of projects.
+ *
+ * ```
+ * slack {
+ *   android {
+ *     library {
+ *       // ...
+ *     }
+ *   }
+ * }
+ * ```
+ */
+fun Project.slack(body: SlackExtension.() -> Unit) {
+  extensions.findByType<SlackExtension>()?.let(body) ?: error("Slack extension not found.")
+}
+
+/**
+ * Common entry point for configuring slack-android-specific bits of projects.
+ *
+ * ```
+ * slackAndroid {
+ *   library {
+ *     // ...
+ *   }
+ * }
+ * ```
+ */
+fun Project.slackAndroid(action: Action<AndroidHandler>) {
+  slack {
+    android(action)
+  }
+}
+
+/**
+ * Common entry point for configuring slack-android-library-specific bits of projects.
+ *
+ * ```
+ * androidApp {
+ *   // ...
+ * }
+ * ```
+ */
+fun Project.slackAndroidApp(action: Action<SlackAndroidAppExtension>) {
+  slack {
+    android {
+      app(action)
+    }
+  }
+}

--- a/buildSrc/src/main/kotlin/Android.kt
+++ b/buildSrc/src/main/kotlin/Android.kt
@@ -1,9 +1,0 @@
-interface BuildType
-
-interface ProductFlavor
-
-interface ApplicationVariant {
-    val name: String
-    val buildType: BuildType
-    val productFlavors: List<ProductFlavor>
-}

--- a/buildSrc/src/main/kotlin/my-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/my-plugin.gradle.kts
@@ -1,2 +1,0 @@
-
-project.extensions.create<SlackExtension>("slack")

--- a/buildSrc/src/main/kotlin/slack/Dsl.kt
+++ b/buildSrc/src/main/kotlin/slack/Dsl.kt
@@ -1,8 +1,13 @@
+package slack
+
+import com.android.build.gradle.api.ApplicationVariant
+import com.android.builder.model.BuildType
+import com.android.builder.model.ProductFlavor
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
-import javax.inject.Inject
-import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.newInstance
 import java.io.File
+import javax.inject.Inject
 
 @DslMarker
 annotation class SlackExtensionMarker

--- a/buildSrc/src/main/kotlin/slack/SlackPlugin.kt
+++ b/buildSrc/src/main/kotlin/slack/SlackPlugin.kt
@@ -1,0 +1,11 @@
+package slack
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
+
+class SlackPlugin : Plugin<Project> {
+  override fun apply(target: Project) {
+    val slackExtension = target.extensions.create<SlackExtension>("slack")
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,18 @@
 rootProject.name = "zac-issue"
+
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+    google()
+    jcenter()
+  }
+  resolutionStrategy {
+    eachPlugin {
+      val requestedId = requested.id.id
+      when {
+        requestedId.startsWith("com.android") -> useModule("com.android.tools.build:gradle:4.0.2")
+      }
+    }
+  }
+}


### PR DESCRIPTION
I'm unfortunately still not able to reproduce it here, but this roughly matches more of our internal implementation short of actually applying the android gradle plugin in the project. Not sure what other areas I can check.

One possible place of interest is the fact that we have top-level package-less functions for running `slackextension` because the kotlin DSL doesn't generate extensions unless we manually apply it in each subproject (we just apply in the root project and it in turn applies to all subprojects internally)